### PR TITLE
Refactor numeric types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# rust_intonation
+
+## v0.2.0 (August 22, 2023)
+
+* Make structs generic against `num::PrimInt` types
+* Default to using `i32` and `f64` numeric types
+
+## v0.1.0 (August 21, 2023)
+
+* Initial release, with support for ratios, tonality diamonds, and n-dimensional lattices.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "rust-intonation"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 clap = { version = "4.3.22", features = ["derive"] }
+num = { version = "0.4.1" }

--- a/README.md
+++ b/README.md
@@ -113,21 +113,23 @@ The possible bounding rules are:
 ### Constructing a Lattice
 
 ```rust
-use rust_intonation::lattice::{Lattice, LatticeDimensions, LatticeDimensionBounds};
-use LatticeDimensionBounds::*;
+use rust_intonation::{
+    lattice::{Lattice, LatticeDimensions, LatticeDimensionBounds},
+    ratio::Ratio
+};
 
 let lattice = Lattice::new(
     vec![
         LatticeDimension::new(
-            Ratio::new(3, 2)
+            Ratio::new(3, 2),
             LatticeDimensionBounds::Infinite,
         ),
         LatticeDimension::new(
-            Ratio::new(5, 4)
+            Ratio::new(5, 4),
             LatticeDimensionBounds::Infinite,
         ),
         LatticeDimension::new(
-            Ratio::new(7, 4)
+            Ratio::new(7, 4),
             LatticeDimensionBounds::Infinite,
         ),
     ]
@@ -142,6 +144,40 @@ lattice.at([1, 0, 0]); // Ratio::new(3, 2)
 lattice.at([1, 1, 0]); // Ratio::new(15, 8)
 lattice.at([1, 1, 1]); // Ratio::new(105, 32)
 lattice.at([-1, -1,- 1]); // Ratio::new(256, 105)
+```
+
+**NB** By default, `rust-intonation` uses 32-bit integers, so with a large enough lattice
+and high enough indices, it *is* possible to encounter integer overflow.
+However, since the largest possible 32-bit integer is `2,147,483,647`, this limit
+should be sufficient for all but the most extreme cases.
+
+#### Avoiding integer overflow
+
+If you need to be able to work with larger ratio components, it is possible to construct
+a `Lattice` using 64-bit integers by explicitly instantiating the Lattice with `<T = i64>`
+
+```rust
+use rust_intonation::{
+    lattice::{Lattice, LatticeDimensions, LatticeDimensionBounds},
+    ratio::Ratio
+};
+
+let lattice: Lattice<i64> = Lattice::new(
+    vec![
+        LatticeDimension::new(
+            Ratio::new(3, 2),
+            LatticeDimensionBounds::Infinite,
+        ),
+        LatticeDimension::new(
+            Ratio::new(5, 4),
+            LatticeDimensionBounds::Infinite,
+        ),
+        LatticeDimension::new(
+            Ratio::new(7, 4),
+            LatticeDimensionBounds::Infinite,
+        ),
+    ]
+);
 ```
 
 ## CLI

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -74,15 +74,15 @@ enum SubCommand {
 pub fn run() {
     let args = Cli::parse();
     match args.cmd {
-        SubCommand::Diamond { limits } => println!("{}", Diamond::new(limits).display()),
+        SubCommand::Diamond { limits } => println!("{}", Diamond::<i32>::new(limits)),
         SubCommand::Lattice { ratios, indices } => {
             let ratios = parse_ratios(ratios);
             let indices = parse_indices(indices);
 
-            let lattice_dimensions = ratios
+            let lattice_dimensions: Vec<LatticeDimension<i32>> = ratios
                 .iter()
                 .map(|r| LatticeDimension::new(*r, Infinite))
-                .collect::<Vec<LatticeDimension>>();
+                .collect();
 
             let lattice = Lattice::new(lattice_dimensions);
 
@@ -98,7 +98,7 @@ pub fn run() {
     }
 }
 
-fn print_ratio(ratio: Ratio) {
+fn print_ratio(ratio: Ratio<i32>) {
     println!(
         "{}\t{:?}",
         ratio,
@@ -114,12 +114,12 @@ fn parse_index(s: &str) -> Vec<i32> {
     s.split(',').map(|n| n.parse().unwrap()).collect()
 }
 
-fn parse_ratios(ratios: Vec<String>) -> Vec<Ratio> {
+fn parse_ratios(ratios: Vec<String>) -> Vec<Ratio<i32>> {
     ratios.iter().map(|r| parse_ratio(r)).collect()
 }
 
-fn parse_ratio(s: &str) -> Ratio {
-    let parts = s.split('/').collect::<Vec<&str>>();
+fn parse_ratio(s: &str) -> Ratio<i32> {
+    let parts: Vec<&str> = s.split('/').collect();
     let numer: i32 = parts[0].parse().unwrap();
     let denom: i32 = parts[1].parse().unwrap();
     Ratio::new(numer, denom)

--- a/src/interval.rs
+++ b/src/interval.rs
@@ -1,6 +1,7 @@
 //! Operations for converting between JI ratios and approximations of ET (cent-based) intervals
 
 use crate::ratio::Ratio;
+use num::traits::PrimInt;
 
 macro_rules! ji_interval {
     ($name:ident $n:tt/$d:tt) => {
@@ -35,8 +36,8 @@ pub enum EqualTemperedInterval {
     MajorSeventh,
 }
 
-impl From<f32> for EqualTemperedInterval {
-    fn from(value: f32) -> Self {
+impl From<f64> for EqualTemperedInterval {
+    fn from(value: f64) -> Self {
         match (value / 100.) % 12. {
             n if n == 0. => Self::PerfectUnison,
             n if n == 1. => Self::MinorSecond,
@@ -57,12 +58,12 @@ impl From<f32> for EqualTemperedInterval {
 
 /// Describes the approximation of an equal tempered interval as a tuple
 /// pair of the named ET interval and a difference from ET, given in cents.
-pub type ApproximateEqualTemperedInterval = (EqualTemperedInterval, f32);
+pub type ApproximateEqualTemperedInterval = (EqualTemperedInterval, f64);
 
-impl From<Ratio> for ApproximateEqualTemperedInterval {
-    fn from(value: Ratio) -> Self {
-        let f: f32 = (&value.normalize()).into();
-        let ji_cents: f32 = 1200. * f.log2();
+impl<T: PrimInt> From<Ratio<T>> for ApproximateEqualTemperedInterval {
+    fn from(value: Ratio<T>) -> Self {
+        let f: f64 = (&value.normalize()).into();
+        let ji_cents: f64 = 1200. * f.log2();
 
         let et_cents = (ji_cents / 100.).round() * 100.;
 
@@ -73,6 +74,7 @@ impl From<Ratio> for ApproximateEqualTemperedInterval {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ratio::Ratio;
     use EqualTemperedInterval::*;
 
     #[test]

--- a/src/lattice/dimension.rs
+++ b/src/lattice/dimension.rs
@@ -1,21 +1,23 @@
 use super::dimension_bounds::LatticeDimensionBounds;
 use crate::ratio::Ratio;
 
+use num::traits::PrimInt;
+
 /// Models one dimension of a lattice, defining the [Ratio] by which to extend the dimension,
 /// as well as the rules for [bounding][LatticeDimensionBounds] the dimension.
-pub struct LatticeDimension {
-    pub ratio: Ratio,
+pub struct LatticeDimension<T: PrimInt> {
+    pub ratio: Ratio<T>,
     pub bounds: LatticeDimensionBounds,
 }
 
-impl LatticeDimension {
-    pub fn new(ratio: Ratio, bounds: LatticeDimensionBounds) -> Self {
+impl<T: PrimInt> LatticeDimension<T> {
+    pub fn new(ratio: Ratio<T>, bounds: LatticeDimensionBounds) -> Self {
         Self { ratio, bounds }
     }
 
     /// Indexes into the dimension, based on the [bounding rules][LatticeDimensionBounds] defined
     /// for the dimension.
-    pub fn at(&self, index: i32) -> Ratio {
+    pub fn at(&self, index: i32) -> Ratio<T> {
         let index = self.bounds.resolve_index(index);
         self.ratio.pow(index)
     }
@@ -25,6 +27,7 @@ impl LatticeDimension {
 mod tests {
     use super::LatticeDimensionBounds::*;
     use super::*;
+    use crate::ratio::Ratio;
 
     #[test]
     fn at_for_unbounded_dimension() {

--- a/src/lattice/mod.rs
+++ b/src/lattice/mod.rs
@@ -7,23 +7,26 @@ use crate::ratio::Ratio;
 pub use dimension::LatticeDimension;
 pub use dimension_bounds::LatticeDimensionBounds;
 
+use num::traits::PrimInt;
+
 /// Models an n-dimensional just intonation ratio lattice, constructed from a vector
 /// of [LatticeDimensions][LatticeDimension].
-pub struct Lattice {
-    pub dimensions: Vec<LatticeDimension>,
+pub struct Lattice<T: PrimInt> {
+    pub dimensions: Vec<LatticeDimension<T>>,
 }
 
-impl Lattice {
-    pub fn new(dimensions: Vec<LatticeDimension>) -> Self {
+impl<T: PrimInt> Lattice<T> {
+    /// Construct a new [Lattice] from a vector of [LatticeDimenions][LatticeDimension]
+    pub fn new(dimensions: Vec<LatticeDimension<T>>) -> Self {
         Self { dimensions }
     }
 
-    pub fn at(&self, indices: &[i32]) -> Ratio {
+    pub fn at(&self, indices: &[i32]) -> Ratio<T> {
         self.dimensions
             .iter()
             .zip(indices.iter())
             .map(|(dim, &index)| dim.at(index))
-            .fold(Ratio::new(1, 1), |r, acc| acc * r)
+            .fold(Ratio::new(num::one(), num::one()), |r, acc| acc * r)
     }
 }
 
@@ -31,6 +34,7 @@ impl Lattice {
 mod tests {
     use super::dimension_bounds::LatticeDimensionBounds::*;
     use super::*;
+    use crate::lattice::dimension::LatticeDimension;
     use crate::ratio::Ratio;
 
     #[test]
@@ -52,5 +56,29 @@ mod tests {
         assert_eq!(l.at(&[1]), Ratio::new(3, 2));
         assert_eq!(l.at(&[1, 0]), Ratio::new(3, 2));
         assert_eq!(l.at(&[1, 1]), Ratio::new(15, 8));
+    }
+
+    #[test]
+    #[should_panic]
+    fn default_i32_lattice_panics() {
+        let l = Lattice::new(vec![
+            LatticeDimension::new(Ratio::new(3, 2), Infinite),
+            LatticeDimension::new(Ratio::new(5, 4), Infinite),
+            LatticeDimension::new(Ratio::new(7, 4), Infinite),
+        ]);
+
+        l.at(&[7, 7, 7]);
+    }
+
+    #[test]
+    fn can_create_an_i64_lattice() {
+        let l: Lattice<i64> = Lattice::new(vec![
+            LatticeDimension::new(Ratio::new(3, 2), Infinite),
+            LatticeDimension::new(Ratio::new(5, 4), Infinite),
+            LatticeDimension::new(Ratio::new(7, 4), Infinite),
+        ]);
+
+        let r = l.at(&[7, 7, 7]);
+        assert_eq!(r, Ratio::new(140710042265625, 70368744177664));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,7 @@ pub mod interval;
 pub mod lattice;
 mod math;
 pub mod ratio;
+
+pub use lattice::{Lattice, LatticeDimension, LatticeDimensionBounds};
+pub use ratio::Ratio;
+

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,4 +1,6 @@
-pub(crate) fn reduce(a: i32, b: i32) -> (i32, i32) {
+use num::{traits::PrimInt, zero};
+
+pub(crate) fn reduce<T: PrimInt>(a: T, b: T) -> (T, T) {
     let g = gcd(a, b);
     (a / g, b / g)
 }
@@ -7,10 +9,10 @@ pub(crate) fn sign_preserving_mod(a: i32, b: i32) -> i32 {
     (a % b + b) % b
 }
 
-fn gcd(a: i32, b: i32) -> i32 {
+fn gcd<T: PrimInt>(a: T, b: T) -> T {
     let mut a = a;
     let mut b = b;
-    while a % b > 0 {
+    while a % b > zero() {
         let t = a % b;
         a = b;
         b = t;
@@ -18,15 +20,15 @@ fn gcd(a: i32, b: i32) -> i32 {
     b
 }
 
-pub(crate) fn greatest_prime_factor(a: i32) -> i32 {
+pub(crate) fn greatest_prime_factor<T: PrimInt>(a: T) -> T {
     let mut a = a;
-    let mut p = 2;
+    let mut p = num::cast(2).unwrap();
 
-    while a > 1 {
-        if a % p == 0 {
-            a /= p;
+    while a > num::one() {
+        if a % p == num::zero() {
+            a = a / p;
         } else {
-            p += 1;
+            p = p + num::one();
         }
     }
     p


### PR DESCRIPTION
* default to f64 for doubles
* Make Ratio, Lattice, and Diamond generic so they can use i32 or i64

Also
===

* implement std::fmt::Display for Diamond
* Refactor diamond output and internals
* Add CHANGELOG.md + update version
