### PR TITLE
Add the ability to play a `Ratio`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     name: "[stable] CI Tests"
     steps:
+      - run: sudo apt install -y --no-install-recommends libasound2-dev pkg-config
+
       - uses: actions/checkout@v3
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     name: "[stable] Clippy"
     steps:
+      - run: sudo apt install -y --no-install-recommends libasound2-dev pkg-config
+
       - uses: actions/checkout@v3
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # rust_intonation
 
+## Unreleased
+
+* Add `Play` trait and implement using `rodio` for `Ratio` and `EqualTemperedInterval`
+* Add `play` and `compare` CLI subcommands
+
 ## v0.2.0 (August 22, 2023)
 
 * Make structs generic against `num::PrimInt` types

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.3.22", features = ["derive"] }
 num = { version = "0.4.1" }
+rodio = { version = "0.17.0" }
+
+[dev-dependencies]
+pretty_assertions = { version = "1.4.0" }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,9 @@
 use crate::diamond::Diamond;
 use crate::lattice::{Lattice, LatticeDimension, LatticeDimensionBounds::*};
+use crate::play::Play;
 use crate::ratio::Ratio;
 use clap::{Parser, Subcommand};
+use std::time::Duration;
 
 #[derive(Parser, Debug)]
 #[clap(author = "Michael Berkowitz", version)]
@@ -23,6 +25,27 @@ struct Cli {
 
 #[derive(Subcommand, Debug, Clone)]
 enum SubCommand {
+    /// Play a given ratio as sine waves.
+    ///
+    /// Will play a root pitch (middle C), the result of
+    /// multiplying that root pitch by the ratio, and then
+    /// the two pitches together as a dyad.
+    ///
+    /// Ex. `rust-intonation play -r 3/2`
+    Play {
+        #[clap(short = 'r', long = "ratio")]
+        ratio: String,
+    },
+    /// Compare given ratio as sine waves with the nearest ET interval.
+    ///
+    /// Plays the same sequence as **play**, but will follow it by playing
+    /// the nearest ET interval to your ratio
+    ///
+    /// Ex. `rust-intonation compare -r 3/2`
+    Compare {
+        #[clap(short = 'r', long = "ratio")]
+        ratio: String,
+    },
     /// Construct a tonality diamond from the given limits.
     ///
     /// Displays a tonality diamond (otonalities on top, utonalities
@@ -74,6 +97,24 @@ enum SubCommand {
 pub fn run() {
     let args = Cli::parse();
     match args.cmd {
+        SubCommand::Play { ratio } => {
+            let ratio = parse_ratio(&ratio);
+            ratio.play();
+            //
+            // std::thread::sleep(Duration::from_secs_f32(0.5));
+            //
+            // let (et, _) = ratio.to_approximate_equal_tempered_interval();
+            // et.play()
+        }
+        SubCommand::Compare { ratio } => {
+            let ratio = parse_ratio(&ratio);
+            ratio.play();
+
+            std::thread::sleep(Duration::from_secs_f32(0.5));
+
+            let (et, _) = ratio.to_approximate_equal_tempered_interval();
+            et.play()
+        }
         SubCommand::Diamond { limits } => println!("{}", Diamond::<i32>::new(limits)),
         SubCommand::Lattice { ratios, indices } => {
             let ratios = parse_ratios(ratios);

--- a/src/diamond.rs
+++ b/src/diamond.rs
@@ -78,6 +78,7 @@ impl<T: PrimInt> Diamond<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn five_limit() {

--- a/src/interval.rs
+++ b/src/interval.rs
@@ -1,5 +1,6 @@
 //! Operations for converting between JI ratios and approximations of ET (cent-based) intervals
 
+use crate::play::{play_dyad, Play};
 use crate::ratio::Ratio;
 use num::traits::PrimInt;
 
@@ -34,6 +35,36 @@ pub enum EqualTemperedInterval {
     MajorSixth,
     MinorSeventh,
     MajorSeventh,
+}
+
+impl Play for EqualTemperedInterval {
+    fn play(&self) {
+        let middle_c = 440. * 2.0_f32.powf(-9. / 12.);
+        let et_steps: usize = self.into();
+        let et_steps = et_steps as f32;
+        let et_freq = middle_c * 2f32.powf(1. / 12.).powf(et_steps);
+
+        play_dyad(middle_c, et_freq);
+    }
+}
+
+impl From<&EqualTemperedInterval> for usize {
+    fn from(value: &EqualTemperedInterval) -> Self {
+        match value {
+            EqualTemperedInterval::PerfectUnison => 0,
+            EqualTemperedInterval::MinorSecond => 1,
+            EqualTemperedInterval::MajorSecond => 2,
+            EqualTemperedInterval::MinorThird => 3,
+            EqualTemperedInterval::MajorThird => 4,
+            EqualTemperedInterval::PerfectFourth => 5,
+            EqualTemperedInterval::AugmentedFourth => 6,
+            EqualTemperedInterval::PerfectFifth => 7,
+            EqualTemperedInterval::MinorSixth => 8,
+            EqualTemperedInterval::MajorSixth => 9,
+            EqualTemperedInterval::MinorSeventh => 10,
+            EqualTemperedInterval::MajorSeventh => 11,
+        }
+    }
 }
 
 impl From<f64> for EqualTemperedInterval {
@@ -75,6 +106,7 @@ impl<T: PrimInt> From<Ratio<T>> for ApproximateEqualTemperedInterval {
 mod tests {
     use super::*;
     use crate::ratio::Ratio;
+    use pretty_assertions::assert_eq;
     use EqualTemperedInterval::*;
 
     #[test]

--- a/src/lattice/dimension.rs
+++ b/src/lattice/dimension.rs
@@ -28,6 +28,7 @@ mod tests {
     use super::LatticeDimensionBounds::*;
     use super::*;
     use crate::ratio::Ratio;
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn at_for_unbounded_dimension() {

--- a/src/lattice/dimension_bounds.rs
+++ b/src/lattice/dimension_bounds.rs
@@ -56,6 +56,7 @@ impl LatticeDimensionBounds {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pretty_assertions::assert_eq;
     use LatticeDimensionBounds::*;
 
     #[test]

--- a/src/lattice/mod.rs
+++ b/src/lattice/mod.rs
@@ -36,6 +36,7 @@ mod tests {
     use super::*;
     use crate::lattice::dimension::LatticeDimension;
     use crate::ratio::Ratio;
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn one_dimensional_unbounded_lattice() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,8 @@ pub mod diamond;
 pub mod interval;
 pub mod lattice;
 mod math;
+pub mod play;
 pub mod ratio;
 
 pub use lattice::{Lattice, LatticeDimension, LatticeDimensionBounds};
 pub use ratio::Ratio;
-

--- a/src/math.rs
+++ b/src/math.rs
@@ -37,6 +37,7 @@ pub(crate) fn greatest_prime_factor<T: PrimInt>(a: T) -> T {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn test_greatest_prime_factor() {

--- a/src/play.rs
+++ b/src/play.rs
@@ -1,0 +1,40 @@
+use rodio::{
+    source::{Amplify, SineWave, Source, TakeDuration},
+    OutputStream, Sink,
+};
+use std::time::Duration;
+pub trait Play {
+    fn play(&self);
+}
+
+pub(crate) fn play_interval(root_freq: f32, interval_freq: f32) {
+    let (_stream, stream_handle) = OutputStream::try_default().unwrap();
+    let sink = Sink::try_new(&stream_handle).unwrap();
+
+    let root = create_sine_wave(root_freq);
+    let interval = create_sine_wave(interval_freq);
+
+    sink.append(root);
+    sink.append(interval);
+    sink.sleep_until_end();
+}
+
+pub(crate) fn play_dyad(root_freq: f32, interval_freq: f32) {
+    let (_stream, stream_handle) = OutputStream::try_default().unwrap();
+    let sink = Sink::try_new(&stream_handle).unwrap();
+    let sink2 = Sink::try_new(&stream_handle).unwrap();
+
+    let root = create_sine_wave(root_freq);
+    let interval = create_sine_wave(interval_freq);
+
+    sink.append(root);
+    sink2.append(interval);
+    sink.sleep_until_end();
+    sink2.sleep_until_end();
+}
+
+pub(crate) fn create_sine_wave(freq: f32) -> Amplify<TakeDuration<SineWave>> {
+    SineWave::new(freq)
+        .take_duration(Duration::from_secs_f32(2.))
+        .amplify(0.2)
+}

--- a/src/ratio.rs
+++ b/src/ratio.rs
@@ -4,8 +4,10 @@
 use crate::{
     interval::ApproximateEqualTemperedInterval,
     math::{greatest_prime_factor, reduce},
+    play::{play_dyad, play_interval, Play},
 };
 use num::traits::PrimInt;
+use std::time::Duration;
 use std::{
     fmt::Display,
     ops::{Div, Mul, Neg},
@@ -16,16 +18,6 @@ use std::{
 pub struct Ratio<T: PrimInt> {
     pub numer: T,
     pub denom: T,
-}
-
-/// Default i32 implementation of [Ratio]
-// pub type Ratio = Ratio<i32>;
-
-impl<T: PrimInt> From<(T, T)> for Ratio<T> {
-    fn from(value: (T, T)) -> Self {
-        let (n, d) = value;
-        Self::new(n, d)
-    }
 }
 
 impl<T: PrimInt> Ratio<T> {
@@ -149,6 +141,21 @@ impl<T: PrimInt> Ratio<T> {
     }
 }
 
+impl<T: PrimInt> Play for Ratio<T> {
+    fn play(&self) {
+        // let middle_c = 261.625565;
+        let middle_c = 440. * 2.0_f32.powf(-9. / 12.);
+        let r: f64 = self.into();
+        let ratio_freq = middle_c * r as f32;
+
+        play_interval(middle_c, ratio_freq);
+
+        std::thread::sleep(Duration::from_secs_f32(0.25));
+
+        play_dyad(middle_c, ratio_freq);
+    }
+}
+
 impl<T: PrimInt + std::fmt::Display> Display for Ratio<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}/{}", self.numer, self.denom)
@@ -187,10 +194,18 @@ impl<T: PrimInt> From<&Ratio<T>> for f64 {
     }
 }
 
+impl<T: PrimInt> From<(T, T)> for Ratio<T> {
+    fn from(value: (T, T)) -> Self {
+        let (n, d) = value;
+        Self::new(n, d)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::interval::EqualTemperedInterval;
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn new_simple_ratio() {


### PR DESCRIPTION
`play` plays a root tone (middle C, in this case), the root tone
multiplied by the `Ratio`, and then the two simultaneously.

`compare` is the same as `play`, but afterwards will play the nearest
12-ET interval
