### PR TITLE
Add support for generic non-12 EDO temperaments

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ let r2 = Ratio::new(5, 4);
 Creating a new ratio will normalize it to the range `[1, 2)`
 
 ```rust
+# use rust_intonation::ratio::Ratio;
 Ratio::new(1, 2); // Ratio::new(1, 1)
 Ratio::new(25, 7); // Ratio::new(25, 14)
 ```
@@ -28,6 +29,9 @@ Ratio::new(25, 7); // Ratio::new(25, 14)
 They can be multiplied and divided with the expected results
 
 ```rust
+# use rust_intonation::ratio::Ratio;
+# let r1 = Ratio::new(3, 2);
+# let r2 = Ratio::new(5, 4);
 r1 * r2; // Ratio::new(15, 8);
 
 r1 / r2; // Ratio::new(6, 5)
@@ -37,6 +41,7 @@ r2 / r1; // Ratio::new(5, 6)
 They can be raised to an integral power (positive or negative)
 
 ```rust
+# use rust_intonation::ratio::Ratio;
 Ratio::new(3, 2).pow(0); // Ratio::new(1, 1)
 Ratio::new(3, 2).pow(2); // Ratio::new(9, 8)
 Ratio::new(3, 2).pow(-2); // Ratio::new(16, 9)
@@ -46,21 +51,24 @@ Their complement can be calculated (given a ratio `r`, its complement
 is the ratio `s` such that `r * s` forms a perfect octave)
 
 ```rust
+# use rust_intonation::ratio::Ratio;
 Ratio::new(3, 2).complement(); // Ratio::new(4, 3)
 Ratio::new(10, 9).complement(); // Ratio::new(9, 5)
 ```
 
-An equal temperament approximation of a JI ratio can be calculated,
+An 12 EDO equal temperament approximation of a JI ratio can be calculated,
 as well as the difference in cents between the JI ratio and the ET
 interval.
 
 ```rust
-Ratio::new(3, 2).to_approximate_equal_tempered_interval(); // (PerfectFifth, 1.954956)
+# use rust_intonation::ratio::Ratio;
+Ratio::new(3, 2).to_approximate_12_edo_interval(); // (PerfectFifth, 1.954956)
 ```
 
 The highest prime limit of the ratio can be calculated
 
 ```rust
+# use rust_intonation::ratio::Ratio;
 Ratio::new(3, 2).limit(); // 3
 Ratio::new(5, 4).limit(); // 5
 Ratio::new(8, 5).limit(); // 5
@@ -73,16 +81,18 @@ A tonality diamond can be constructed from a vector of integer limits
 ```rust
 use rust_intonation::diamond::Diamond;
 
-let diamond = Diamond::new(vec![1, 5, 3]);
+let diamond: Diamond<i32> = Diamond::new(vec![1, 5, 3]);
 ```
 
 The diamond can then be printed out with otonalities on the top, and
 utonalities on the bottom:
 
 ```rust
-println!("{}", diamond.display());
+# use rust_intonation::diamond::Diamond;
+# let diamond: Diamond<i32> = Diamond::new(vec![1, 5, 3]);
+println!("{}", diamond);
 ```
-```
+```bash
                 3/2
 
         5/4             6/5
@@ -114,7 +124,7 @@ The possible bounding rules are:
 
 ```rust
 use rust_intonation::{
-    lattice::{Lattice, LatticeDimensions, LatticeDimensionBounds},
+    lattice::{Lattice, LatticeDimension, LatticeDimensionBounds},
     ratio::Ratio
 };
 
@@ -139,11 +149,31 @@ let lattice = Lattice::new(
 You can then index into the lattice to return the ratio at the given coordinates:
 
 ```rust
-lattice.at([0, 0, 0]); // Ratio::new(1, 1)
-lattice.at([1, 0, 0]); // Ratio::new(3, 2)
-lattice.at([1, 1, 0]); // Ratio::new(15, 8)
-lattice.at([1, 1, 1]); // Ratio::new(105, 32)
-lattice.at([-1, -1,- 1]); // Ratio::new(256, 105)
+# use rust_intonation::{
+#     lattice::{Lattice, LatticeDimension, LatticeDimensionBounds},
+#     ratio::Ratio
+# };
+# let lattice = Lattice::new(
+#     vec![
+#         LatticeDimension::new(
+#             Ratio::new(3, 2),
+#             LatticeDimensionBounds::Infinite,
+#         ),
+#         LatticeDimension::new(
+#             Ratio::new(5, 4),
+#             LatticeDimensionBounds::Infinite,
+#         ),
+#         LatticeDimension::new(
+#             Ratio::new(7, 4),
+#             LatticeDimensionBounds::Infinite,
+#         ),
+#     ]
+# );
+lattice.at(&[0, 0, 0]); // Ratio::new(1, 1)
+lattice.at(&[1, 0, 0]); // Ratio::new(3, 2)
+lattice.at(&[1, 1, 0]); // Ratio::new(15, 8)
+lattice.at(&[1, 1, 1]); // Ratio::new(105, 32)
+lattice.at(&[-1, -1,- 1]); // Ratio::new(256, 105)
 ```
 
 **NB** By default, `rust-intonation` uses 32-bit integers, so with a large enough lattice
@@ -158,7 +188,7 @@ a `Lattice` using 64-bit integers by explicitly instantiating the Lattice with `
 
 ```rust
 use rust_intonation::{
-    lattice::{Lattice, LatticeDimensions, LatticeDimensionBounds},
+    lattice::{Lattice, LatticeDimension, LatticeDimensionBounds},
     ratio::Ratio
 };
 
@@ -236,5 +266,37 @@ $ rust-intonation lattice --ratios 3/2 5/4 7/4 --indices 1,1,1 2,2,2 -1,0,1
 7/3     (MinorThird, -33.12915)
 ```
 
-**NB** that each n-dimensional index coordinate set is comma-separated, but
+**NB** each n-dimensional index coordinate set is comma-separated, but
 the different coordinates are separated by spaces.
+
+### play
+
+This command plays the given ratio as sine waves, based on middle C (C4). For example,
+the following command will play a JI perfect fifth.
+
+```bash
+$ rust-intonation play --ratio 3/2
+```
+
+### compare
+
+Similar to `play`, this command will play the given ratio as a pair of sine waves, but will follow it
+by playing the nearest 12EDO interval, also starting on middle C (C4).
+
+```bash
+$ rust-intonation play --ratio 3/2
+```
+
+### series
+
+Will print out the first N members of the harmonic series, showing the harmonic number,
+the ratio, and the nearest 12EDO interval.
+
+```bash
+$ rust-intonation series --limit 5
+5       5/4     (MajorThird, -13.686286135165176)
+4       1/1     (PerfectUnison, 0.0)
+3       3/2     (PerfectFifth, 1.955000865387433)
+2       1/1     (PerfectUnison, 0.0)
+1       1/1     (PerfectUnison, 0.0)
+```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,5 @@
+//! the rust-intonation CLI. See [rust-intonation][crate] for documentation.
+
 use crate::diamond::Diamond;
 use crate::lattice::{Lattice, LatticeDimension, LatticeDimensionBounds::*};
 use crate::play::Play;
@@ -92,6 +94,14 @@ enum SubCommand {
         #[clap(short = 'r', long = "ratio", num_args = 0..)]
         ratios: Vec<String>,
     },
+    /// Prints out the harmonic series from the given limit down to 1.
+    ///
+    /// Prints each harmonic as a JI ratio, along with the nearest 12EDO interval
+    /// and the cents difference between them
+    Series {
+        #[clap(short = 'l', long = "limit")]
+        limit: i32,
+    },
 }
 
 pub fn run() {
@@ -100,11 +110,6 @@ pub fn run() {
         SubCommand::Play { ratio } => {
             let ratio = parse_ratio(&ratio);
             ratio.play();
-            //
-            // std::thread::sleep(Duration::from_secs_f32(0.5));
-            //
-            // let (et, _) = ratio.to_approximate_equal_tempered_interval();
-            // et.play()
         }
         SubCommand::Compare { ratio } => {
             let ratio = parse_ratio(&ratio);
@@ -112,7 +117,7 @@ pub fn run() {
 
             std::thread::sleep(Duration::from_secs_f32(0.5));
 
-            let (et, _) = ratio.to_approximate_equal_tempered_interval();
+            let (et, _) = ratio.to_approximate_12_edo_interval();
             et.play()
         }
         SubCommand::Diamond { limits } => println!("{}", Diamond::<i32>::new(limits)),
@@ -136,15 +141,18 @@ pub fn run() {
                 print_ratio(ratio);
             }
         }
+        SubCommand::Series { limit } => {
+            for i in (1..=limit).rev() {
+                let r = Ratio::new(i, 1);
+                print!("{}\t", i);
+                print_ratio(r);
+            }
+        }
     }
 }
 
 fn print_ratio(ratio: Ratio<i32>) {
-    println!(
-        "{}\t{:?}",
-        ratio,
-        ratio.to_approximate_equal_tempered_interval()
-    );
+    println!("{}\t{:?}", ratio, ratio.to_approximate_12_edo_interval());
 }
 
 fn parse_indices(indices: Vec<String>) -> Vec<Vec<i32>> {

--- a/src/diamond.rs
+++ b/src/diamond.rs
@@ -1,10 +1,12 @@
+//! Tools for constructing and displaying a tonality diamond from a set of prime limits.
 use num::PrimInt;
 
 use crate::ratio::Ratio;
 use std::{fmt::Display, marker::PhantomData};
 
+/// Models a tonality diamond with the given prime limits
 pub struct Diamond<T: PrimInt = i32> {
-    pub identities: Vec<u32>,
+    pub limits: Vec<u32>,
     phantom: PhantomData<T>,
 }
 
@@ -25,29 +27,29 @@ type Coordinate = (usize, usize);
 type Coordinates = Vec<Coordinate>;
 
 impl<T: PrimInt> Diamond<T> {
-    pub fn new(identities: Vec<u32>) -> Self {
+    pub fn new(limits: Vec<u32>) -> Self {
         Self {
-            identities,
+            limits,
             phantom: PhantomData::<T>,
         }
     }
 
     pub fn generate(&self) -> Vec<Vec<Ratio<i32>>> {
-        self.identities
+        self.limits
             .iter()
             .map(|d| self.construct_ratios_with_denominator(*d as i32))
             .collect()
     }
 
     fn construct_ratios_with_denominator(&self, denominator: i32) -> Vec<Ratio<i32>> {
-        self.identities
+        self.limits
             .iter()
             .map(|n| Ratio::new(*n as i32, denominator))
             .collect()
     }
 
     fn construct_diamond_row(&self, row: &[Coordinate], ratios: &[Vec<Ratio<i32>>]) -> String {
-        let prefix_len = self.identities.len() - row.len();
+        let prefix_len = self.limits.len() - row.len();
         let prefix = "\t".repeat(prefix_len);
         format!(
             "{}{}",
@@ -60,7 +62,7 @@ impl<T: PrimInt> Diamond<T> {
     }
 
     fn index_coordinates(&self) -> Vec<Coordinates> {
-        let max = self.identities.len() - 1;
+        let max = self.limits.len() - 1;
         let mut coordinate_rows = vec![];
         for i in (0..=max).rev() {
             let row: Coordinates = (i..=max).enumerate().collect();

--- a/src/interval.rs
+++ b/src/interval.rs
@@ -2,6 +2,7 @@
 
 use crate::play::{play_dyad, Play};
 use crate::ratio::Ratio;
+use crate::temperaments::edo::EdoInterval;
 use num::traits::PrimInt;
 
 macro_rules! ji_interval {
@@ -89,9 +90,9 @@ impl From<f64> for TwelveEDOInterval {
 
 /// Describes the approximation of an equal tempered interval as a tuple
 /// pair of the named ET interval and a difference from ET, given in cents.
-pub type ApproximateEqualTemperedInterval = (TwelveEDOInterval, f64);
+pub type Approximate12EDOInterval = (TwelveEDOInterval, f64);
 
-impl<T: PrimInt> From<Ratio<T>> for ApproximateEqualTemperedInterval {
+impl<T: PrimInt> From<Ratio<T>> for Approximate12EDOInterval {
     fn from(value: Ratio<T>) -> Self {
         let f: f64 = (&value).into();
         let ji_cents: f64 = 1200. * f.log2();
@@ -99,6 +100,14 @@ impl<T: PrimInt> From<Ratio<T>> for ApproximateEqualTemperedInterval {
         let et_cents = (ji_cents / 100.).round() * 100.;
 
         (et_cents.into(), ji_cents - et_cents)
+    }
+}
+
+impl<'a> From<EdoInterval<'a>> for Approximate12EDOInterval {
+    fn from(value: EdoInterval<'a>) -> Self {
+        let non_12_cents: f64 = value.cents as f64;
+        let et_12_cents: f64 = (non_12_cents / 100.).round() * 100.;
+        (et_12_cents.into(), non_12_cents - et_12_cents)
     }
 }
 
@@ -110,24 +119,16 @@ mod tests {
     use TwelveEDOInterval::*;
 
     #[test]
-    fn unison_and_octaves() {
+    fn unison() {
         let r1 = Ratio::new(1, 1);
-        let i1: ApproximateEqualTemperedInterval = r1.into();
+        let i1: Approximate12EDOInterval = r1.into();
         assert_eq!(i1, (PerfectUnison, 0.));
-
-        let r2 = Ratio::new(2, 1);
-        let i2: ApproximateEqualTemperedInterval = r2.into();
-        assert_eq!(i2, (PerfectUnison, 0.));
-
-        let r3 = Ratio::new(1, 2);
-        let i3: ApproximateEqualTemperedInterval = r3.into();
-        assert_eq!(i3, (PerfectUnison, 0.));
     }
 
     #[test]
     fn perfect_fifth() {
         let r = Ratio::new(3, 2);
-        let i: ApproximateEqualTemperedInterval = r.into();
+        let i: Approximate12EDOInterval = r.into();
         assert_eq!(i.0, PerfectFifth);
         assert!((i.1 - 1.955).abs() < 0.001);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 pub mod cli;
 pub mod diamond;
 pub mod interval;
@@ -5,6 +7,8 @@ pub mod lattice;
 mod math;
 pub mod play;
 pub mod ratio;
+pub mod temperaments;
 
 pub use lattice::{Lattice, LatticeDimension, LatticeDimensionBounds};
 pub use ratio::Ratio;
+pub use temperaments::Edo;

--- a/src/math.rs
+++ b/src/math.rs
@@ -10,14 +10,6 @@ pub(crate) fn normalize_pair<T: PrimInt>(a: T, b: T) -> (T, T) {
         _ => (a, b),
     }
 }
-// let f: f64 = self.into();
-// let two: T = num::cast(2i32).unwrap();
-//
-// match f {
-//     f if f < 1. => Self::new(self.numer * two, self.denom),
-//     f if f >= 2. => Self::new(self.numer, self.denom * two),
-//     _ => Self::new(self.numer, self.denom),
-// }
 
 pub(crate) fn reduce<T: PrimInt>(a: T, b: T) -> (T, T) {
     let g = gcd(a, b);

--- a/src/play.rs
+++ b/src/play.rs
@@ -1,8 +1,11 @@
+//! Helpers for playback via [rodio](https://docs.rs/rodio).
 use rodio::{
     source::{Amplify, SineWave, Source, TakeDuration},
     OutputStream, Sink,
 };
 use std::time::Duration;
+
+/// Trait to allow playback using [rodio](https://docs.rs/rodio).
 pub trait Play {
     fn play(&self);
 }

--- a/src/ratio.rs
+++ b/src/ratio.rs
@@ -2,7 +2,7 @@
 //!
 
 use crate::{
-    interval::ApproximateEqualTemperedInterval,
+    interval::Approximate12EDOInterval,
     math::{greatest_prime_factor, normalize_pair, reduce},
     play::{play_dyad, play_interval, Play},
 };
@@ -87,12 +87,12 @@ impl<T: PrimInt> Ratio<T> {
     /// # use rust_intonation::interval::TwelveEDOInterval;
     /// let r = Ratio::new(3, 2);
     /// assert_eq!(
-    ///   r.to_approximate_equal_tempered_interval(),
+    ///   r.to_approximate_12_edo_interval(),
     ///   (TwelveEDOInterval::PerfectFifth, 1.955000865387433)
     /// );
     /// ```
     /// This shows that a JI ratio of 3/2 is approximately 2 cents wider than an ET perfect 5th.
-    pub fn to_approximate_equal_tempered_interval(&self) -> ApproximateEqualTemperedInterval {
+    pub fn to_approximate_12_edo_interval(&self) -> Approximate12EDOInterval {
         (*self).into()
     }
 
@@ -247,7 +247,7 @@ mod tests {
     #[test]
     fn to_modified_et_interval() {
         let r = Ratio::new(3, 2);
-        let i = r.to_approximate_equal_tempered_interval();
+        let i = r.to_approximate_12_edo_interval();
         assert_eq!(i.0, TwelveEDOInterval::PerfectFifth);
         assert!((i.1 - 1.955).abs() < 0.0001);
     }

--- a/src/temperaments/edo.rs
+++ b/src/temperaments/edo.rs
@@ -1,0 +1,101 @@
+//! Functions and structs for generating temperaments that are made by equal divisions
+//! of the octave (EDO)
+use crate::interval::Approximate12EDOInterval;
+
+/// Models an EDO that divides the octave into the given number of equal divisions.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Edo {
+    pub divisions: u32,
+}
+
+/// Models an interval of a given number of steps in a specified EDO temperament.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct EdoInterval<'a> {
+    edo: &'a Edo,
+    steps: u32,
+    pub cents: f32,
+}
+
+impl Edo {
+    /// Create a new EDO temperament which divides the octave evenly into a given number of
+    /// divisions.
+    pub fn new(divisions: u32) -> Self {
+        Self { divisions }
+    }
+
+    /// Returns an [interval][EdoInterval] that represents an interval of the given number of steps
+    /// in the subject EDO.
+    pub fn interval(&self, steps: u32) -> EdoInterval {
+        EdoInterval::new(self, steps)
+    }
+}
+
+impl<'a> EdoInterval<'a> {
+    /// Calculates an interval of the given number of steps in a specified EDO temperament.
+    ///
+    /// Sholud generally not be called directly. See [Edo::interval](crate::Edo::interval)
+    pub fn new(edo: &'a Edo, steps: u32) -> EdoInterval<'a> {
+        let cents = 1200. * (steps as f32) / (edo.divisions as f32);
+        Self { edo, steps, cents }
+    }
+
+    /// Returns an approximation of the interval in 12 EDO temperament, giving the closest 12 EDO
+    /// interval name, and the number of cents by which the subject interval differs from that
+    /// interval.
+    pub fn to_approximate_12_edo_interval(&self) -> Approximate12EDOInterval {
+        (*self).into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::interval::TwelveEDOInterval;
+
+    use super::*;
+
+    #[test]
+    fn interval() {
+        let twelve = Edo::new(12);
+
+        let fifth = twelve.interval(7);
+
+        assert_eq!(fifth.steps, 7);
+        assert_eq!(fifth.edo, &twelve);
+        assert_eq!(fifth.cents, 700.);
+
+        let sixth = twelve.interval(9);
+        assert_eq!(sixth.steps, 9);
+        assert_eq!(sixth.edo, &twelve);
+        assert_eq!(sixth.cents, 900.);
+    }
+
+    #[test]
+    fn non_12_edo() {
+        let fifty_three = Edo::new(53);
+
+        let fifth = fifty_three.interval(31);
+
+        assert_eq!(fifth.steps, 31);
+        assert_eq!(fifth.edo, &fifty_three);
+        assert_eq!(fifth.cents, 701.8868);
+    }
+
+    #[test]
+    fn closest_12_edo() {
+        let twelve = Edo::new(12);
+        let fifty_three = Edo::new(53);
+
+        let fifth = twelve.interval(7);
+        let fifth53 = fifty_three.interval(31);
+
+        let approx = fifth.to_approximate_12_edo_interval();
+
+        assert_eq!(approx.0, TwelveEDOInterval::PerfectFifth);
+        assert_eq!(approx.1, 0.);
+
+        let approx53 = fifth53.to_approximate_12_edo_interval();
+
+        assert_eq!(approx53.0, TwelveEDOInterval::PerfectFifth);
+        assert!((approx53.1 - 1.8868).abs() < 0.0001);
+    }
+}

--- a/src/temperaments/mod.rs
+++ b/src/temperaments/mod.rs
@@ -1,0 +1,5 @@
+//! Structs and functions for working with other scale temperaments
+
+pub mod edo;
+
+pub use edo::Edo;


### PR DESCRIPTION
* Add Edo and EdoInterval structs to allow non-12 EDO temperaments
* Make 12EDO intervals explicitly named as such
* Add documentation (and accidentally include other documentation)
